### PR TITLE
Add cracklib-dicts package

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,7 @@ RUN echo 'install_weak_deps=False' >> /etc/dnf/dnf.conf \
   && dnf install \
     pcs \
     which \
+    cracklib-dicts \
   && dnf clean all
 
 RUN mkdir -p /etc/systemd/system-preset \


### PR DESCRIPTION
Add missing package required for changing `hacluster` password.
Bug:
```
[root@pacemaker-node1 /]# passwd hacluster
New password: 
/usr/share/cracklib/pw_dict.pwd.gz: No such file or directory
BAD PASSWORD: The password fails the dictionary check - error loading dictionary
```

Result:
```
[root@pacemaker-node1 /]# passwd hacluster
New password: 
Retype new password: 
passwd: password updated successfully
```